### PR TITLE
Server save requested state pre enable

### DIFF
--- a/server/light_viz_protocols.py
+++ b/server/light_viz_protocols.py
@@ -185,12 +185,12 @@ class LightVizClip(pv_protocols.ParaViewWebProtocol):
         dataset_manager.addListener(self)
 
     def dataChanged(self):
+        self.updateRepresentation('Surface')
+        self.updateColorBy('__SOLID__')
         if self.clipX:
             self.clipX.Input = self.ds.getInput()
             self.updatePosition(50, 50, 50)
             self.updateInsideOut(False, False, False)
-            self.representation.Representation = 'Surface'
-            self.representation.ColorArrayName = ''
             self.representation.Visibility = 0
 
     @exportRpc("light.viz.clip.getstate")
@@ -316,6 +316,8 @@ class LightVizContour(pv_protocols.ParaViewWebProtocol):
         dataset_manager.addListener(self)
 
     def dataChanged(self):
+        self.updateRepresentation('Surface')
+        self.updateColorBy('__SOLID__')
         if self.contour:
             self.contour.Input = self.ds.getInput()
             self.representation.Visibility = 0
@@ -419,6 +421,8 @@ class LightVizSlice(pv_protocols.ParaViewWebProtocol):
         dataset_manager.addListener(self)
 
     def dataChanged(self):
+        self.updateRepresentation('Surface')
+        self.updateColorBy('__SOLID__')
         if self.sliceX:
             self.sliceX.Input = self.ds.getInput()
             self.sliceY.Input = self.ds.getInput()
@@ -434,8 +438,6 @@ class LightVizSlice(pv_protocols.ParaViewWebProtocol):
             self.representationY.Visibility = 0
             self.representationZ.Visibility = 0
             self.enabled = False
-            self.reprMode = 'Surface'
-            self.colorBy = '__SOLID__'
 
     @exportRpc("light.viz.slice.getstate")
     def getState(self):
@@ -576,6 +578,8 @@ class LightVizMultiSlice(pv_protocols.ParaViewWebProtocol):
         dataset_manager.addListener(self)
 
     def dataChanged(self):
+        self.updateRepresentation('Surface')
+        self.updateColorBy('__SOLID__')
         if self.slice:
             self.slice.Input = self.ds.getInput()
             self.updatePosition(50, 50, 50)

--- a/server/light_viz_protocols.py
+++ b/server/light_viz_protocols.py
@@ -254,7 +254,7 @@ class LightVizClip(pv_protocols.ParaViewWebProtocol):
     @exportRpc("light.viz.clip.color")
     def updateColorBy(self, field):
         if self.representation:
-            if field == '__SOLID':
+            if field == '__SOLID__':
                 self.representation.ColorArrayName = ''
             else:
                 # Select data array
@@ -356,7 +356,7 @@ class LightVizContour(pv_protocols.ParaViewWebProtocol):
     @exportRpc("light.viz.contour.color")
     def updateColorBy(self, field):
         if self.representation:
-            if field == '__SOLID':
+            if field == '__SOLID__':
                 self.representation.ColorArrayName = ''
             else:
                 # Select data array
@@ -480,7 +480,7 @@ class LightVizSlice(pv_protocols.ParaViewWebProtocol):
     @exportRpc("light.viz.slice.color")
     def updateColorBy(self, field):
         if self.representationX:
-            if field == '__SOLID':
+            if field == '__SOLID__':
                 self.representationX.ColorArrayName = ''
                 self.representationY.ColorArrayName = ''
                 self.representationZ.ColorArrayName = ''
@@ -606,7 +606,7 @@ class LightVizMultiSlice(pv_protocols.ParaViewWebProtocol):
     @exportRpc("light.viz.mslice.color")
     def updateColorBy(self, field):
         if self.representation:
-            if field == '__SOLID':
+            if field == '__SOLID__':
                 self.representation.ColorArrayName = ''
             else:
                 # Select data array


### PR DESCRIPTION
@jourdain Here are some server-side fixes that I have made this morning.  Essentially, changes made to the representation and color by arrays before a module is enabled are saved server-side and used when the module is enabled.

The only thing left I'd like to do on this branch is to figure out how to get the initial color by on the contour to be right...